### PR TITLE
Limit length of pasted string to 250

### DIFF
--- a/main.scpt
+++ b/main.scpt
@@ -2,7 +2,7 @@ set numbers_key_codes to {82, 83, 84, 85, 86, 87, 88, 89, 91, 92}
 
 set input to do shell script "pbpaste"
 
-if (input is not missing value) then
+if (input is not missing value and length of input is less than 250) then
 	tell application "System Events"
 		repeat with char in the characters of input
 			try


### PR DESCRIPTION
To prevent hanging the host for too long.

Closes #4